### PR TITLE
Add email field and validation to payment page

### DIFF
--- a/pages/pay.tsx
+++ b/pages/pay.tsx
@@ -6,7 +6,7 @@ import { Elements, PaymentElement, useElements, useStripe } from '@stripe/react-
 
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || '');
 
-function CheckoutForm(){
+function CheckoutForm({emailValid}:{emailValid:boolean}){
   const stripe=useStripe(); const elements=useElements();
   const [submitting,setSubmitting]=useState(false);
   const [error,setError]=useState<string|undefined>();
@@ -21,7 +21,7 @@ function CheckoutForm(){
 
   return(<form onSubmit={onSubmit} className="max-w-md mx-auto card mt-8">
     <PaymentElement/>
-    <button disabled={!stripe||submitting} className="btn w-full mt-4">{submitting?'Processing...':'Pay'}</button>
+    <button disabled={!stripe||submitting||!emailValid} className="btn w-full mt-4">{submitting?'Processing...':'Pay'}</button>
     {error&&<p className="text-red-400 text-sm mt-2">{error}</p>}
   </form>);
 }
@@ -30,6 +30,8 @@ export default function PayPage(){
   const router=useRouter();
   const {teamId,witchId,type}=router.query as {teamId?:string;witchId?:string;type?:'bless'|'curse'};
   const [note,setNote]=useState('');
+  const [email,setEmail]=useState('');
+  const emailValid=/^[^@]+@[^@]+\.[^@]+$/.test(email);
   const init=useMemo(()=>({teamId:Number(teamId),witchId:Number(witchId),type:(type||'curse') as 'bless'|'curse'}),[teamId,witchId,type]);
   const [clientSecret,setClientSecret]=useState<string|null>(null);
   const [intentError,setIntentError]=useState<string|null>(null);
@@ -37,7 +39,7 @@ export default function PayPage(){
   useEffect(()=>{ if(!init.teamId||!init.witchId) return; (async()=>{
     try{
       setIntentError(null);
-      const res=await fetch('/api/create_payment_intent',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({...init,note})});
+      const res=await fetch('/api/create_payment_intent',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({...init,note,email})});
       if(!res.ok){
         const message=await res.text();
         throw new Error(message||'Failed to create payment intent');
@@ -47,12 +49,14 @@ export default function PayPage(){
       console.error(err);
       setIntentError(err instanceof Error?err.message:'Failed to create payment intent');
     }
-  })()},[init,note]);
+  })()},[init,note,email]);
 
   if(!init.teamId||!init.witchId) return <main className="max-w-xl mx-auto p-6">Missing selection. Go back and pick a team and witch.</main>;
   if(!clientSecret) return <main className="max-w-xl mx-auto p-6">
     <h1 className="text-2xl font-bold mb-3">Add your intent</h1>
-    <label className="block text-sm mb-2">What exactly are you blessing/curing? (free text)</label>
+    <label className="block text-sm mb-2">Email</label>
+    <input type="email" value={email} onChange={e=>setEmail(e.target.value)} className="w-full p-2 rounded bg-black/40 border border-gray-700"/>
+    <label className="block text-sm mb-2 mt-4">What exactly are you blessing/curing? (free text)</label>
     <textarea value={note} onChange={e=>setNote(e.target.value)} className="w-full p-2 rounded bg-black/40 border border-gray-700" rows={4} placeholder="e.g., Bless the Bears' O-line vs Packers, Week 1"/>
     {intentError?<p className="text-red-400 text-sm mt-3">{intentError}</p>:<div className="opacity-70 text-sm mt-3">Preparing payment...</div>}
   </main>;
@@ -60,9 +64,11 @@ export default function PayPage(){
   return(<Elements stripe={stripePromise!} options={{clientSecret}}>
     <main className="max-w-xl mx-auto p-6">
       <h1 className="text-2xl font-bold">Complete your {init.type}</h1>
+      <label className="block text-sm mb-2 mt-4">Email</label>
+      <input type="email" value={email} onChange={e=>setEmail(e.target.value)} className="w-full p-2 rounded bg-black/40 border border-gray-700"/>
       <label className="block text-sm mb-2 mt-4">What exactly are you blessing/curing? (free text)</label>
       <textarea value={note} onChange={e=>setNote(e.target.value)} className="w-full p-2 rounded bg-black/40 border border-gray-700" rows={4} placeholder="e.g., Bless the Bears' O-line vs Packers, Week 1"/>
-      <CheckoutForm/>
+      <CheckoutForm emailValid={emailValid}/>
     </main>
   </Elements>);
 }


### PR DESCRIPTION
## Summary
- capture user email before entering payment details and note
- send email with payment intent request and require valid email before submission

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f297eec88332a59959eaf07e7326