### PR TITLE
Include email in Stripe payment intent

### DIFF
--- a/pages/api/create_payment_intent.ts
+++ b/pages/api/create_payment_intent.ts
@@ -7,12 +7,13 @@ const stripe=new Stripe(process.env.STRIPE_SECRET_KEY||'',{apiVersion:'2023-10-1
 
 export default async function handler(req:NextApiRequest,res:NextApiResponse){
   if(req.method!=='POST') return res.status(405).end();
-  const {teamId,witchId,type,note}=req.body as {teamId:number;witchId:number;type:'bless'|'curse';note?:string};
+  const {teamId,witchId,type,note,email}=req.body as {teamId:number;witchId:number;type:'bless'|'curse';note?:string;email?:string};
   const {data:w,error}=await supabase.from('witches').select('name,price_cents').eq('id',witchId).single();
   if(error||!w) return res.status(400).json({error:'Invalid witch'});
   const pi=await stripe.paymentIntents.create({
     amount:w.price_cents,currency:'usd',description:`${type.toUpperCase()} by ${w.name}`,
-    metadata:{teamId:String(teamId),witchId:String(witchId),type,note:note||''},
+    receipt_email:email,
+    metadata:{teamId:String(teamId),witchId:String(witchId),type,note:note||'',email:email||''},
     automatic_payment_methods:{enabled:true},
   });
   res.json({clientSecret:pi.client_secret});


### PR DESCRIPTION
## Summary
- parse `email` from request body
- send Stripe `receipt_email` and store `email` in metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b9f2b198a08332bc4e7c3856cdcfaa