### PR TITLE
Record email on orders and show in admin

### DIFF
--- a/data/schema.sql
+++ b/data/schema.sql
@@ -22,6 +22,7 @@ create table if not exists orders(
   witch_id bigint references witches(id) on delete set null,
   team_id bigint references teams(id) on delete set null,
   type spell_type not null,
+  email text,
   status text not null default 'pending',
   paid_at timestamptz,
   result text,
@@ -29,6 +30,8 @@ create table if not exists orders(
   note text,
   created_at timestamptz not null default now()
 );
+
+alter table orders add column if not exists email text;
 
 create or replace function witch_leaderboard()
 returns table (witch_id bigint, name text, spells bigint, hits bigint, weighted_hits numeric, image_url text)

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -16,6 +16,7 @@ type OrderRow = {
   note: string|null;
   witch_name: string|null;
   team_name: string|null;
+  email: string|null;
 };
 
 export default function Admin(){
@@ -38,14 +39,14 @@ export default function Admin(){
     (async()=>{
       const { data, error } = await supabase
         .from('orders')
-        .select('id,created_at,team_id,witch_id,type,status,paid_at,result,factor,note, witches(name), teams(name)')
+        .select('id,created_at,team_id,witch_id,type,status,paid_at,result,factor,note,email, witches(name), teams(name)')
         .order('created_at', { ascending:false })
         .limit(100);
       if(!error && data){
         const mapped = (data as any[]).map(d => ({
           id: d.id, created_at: d.created_at, team_id: d.team_id, witch_id: d.witch_id, type: d.type,
           status: d.status, paid_at: d.paid_at, result: d.result, factor: d.factor, note: d.note,
-          witch_name: d.witches?.name ?? null, team_name: d.teams?.name ?? null
+          witch_name: d.witches?.name ?? null, team_name: d.teams?.name ?? null, email: d.email ?? null
         }));
         setRows(mapped);
       }
@@ -75,6 +76,7 @@ export default function Admin(){
             <div className="text-sm opacity-70">{new Date(r.created_at).toLocaleString()}</div>
             <div className="font-semibold mt-1">{r.witch_name || 'Unknown Witch'} &rarr; {r.type.toUpperCase()} on {r.team_name || 'Unknown Team'}</div>
             {r.note && <div className="text-sm mt-1 opacity-80">Note: {r.note}</div>}
+            {r.email && <div className="text-sm mt-1 opacity-80">Email: {r.email}</div>}
             <div className="flex items-center gap-3 mt-3">
               <label className="text-sm">Result:</label>
               <select value={r.result ?? ''} onChange={e=>{ const v=e.target.value||null; setRows(rows.map(x=>x.id===r.id?{...x,result:v as any}:x))}} className="bg-black/40 border border-gray-700 rounded p-1">

--- a/pages/api/webhook.ts
+++ b/pages/api/webhook.ts
@@ -21,6 +21,7 @@ export default async function handler(req:NextApiRequest,res:NextApiResponse){
       witch_id:Number(witchId),
       type,
       note: note || null,
+      email: (pi.receipt_email || (pi.metadata as any)?.email) || null,
       factor: 1.0,
       paid_at:new Date().toISOString(),
       status:'paid'


### PR DESCRIPTION
## Summary
- add `email` column to orders table and migration
- store receipt email from Stripe webhook when creating orders
- expose email field on admin orders view

## Testing
- `NEXT_PUBLIC_SUPABASE_URL='http://localhost' NEXT_PUBLIC_SUPABASE_ANON_KEY='anon' npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9f2b3ad3083328cd89de8db518972