### PR TITLE
Handle long payment intent notes

### DIFF
--- a/pages/api/create_payment_intent.ts
+++ b/pages/api/create_payment_intent.ts
@@ -4,16 +4,31 @@ import Stripe from 'stripe';
 import { supabase } from '../../lib/supabaseClient';
 
 const stripe=new Stripe(process.env.STRIPE_SECRET_KEY||'',{apiVersion:'2023-10-16'});
+const NOTE_MAX_LENGTH=500;
+
+const clampMetadataValue=(value:string)=>Array.from(value).slice(0,NOTE_MAX_LENGTH).join('');
 
 export default async function handler(req:NextApiRequest,res:NextApiResponse){
   if(req.method!=='POST') return res.status(405).end();
   const {teamId,witchId,type,note}=req.body as {teamId:number;witchId:number;type:'bless'|'curse';note?:string};
-  const {data:w,error}=await supabase.from('witches').select('name,price_cents').eq('id',witchId).single();
-  if(error||!w) return res.status(400).json({error:'Invalid witch'});
-  const pi=await stripe.paymentIntents.create({
-    amount:w.price_cents,currency:'usd',description:`${type.toUpperCase()} by ${w.name}`,
-    metadata:{teamId:String(teamId),witchId:String(witchId),type,note:note||''},
-    automatic_payment_methods:{enabled:true},
-  });
-  res.json({clientSecret:pi.client_secret});
+  const teamIdNum=Number(teamId); const witchIdNum=Number(witchId);
+  if(!Number.isInteger(teamIdNum)||teamIdNum<=0||!Number.isInteger(witchIdNum)||witchIdNum<=0) return res.status(400).json({error:'Invalid team or witch'});
+  if(type!=='bless'&&type!=='curse') return res.status(400).json({error:'Invalid spell type'});
+  const sanitizedNote=typeof note==='string'?clampMetadataValue(note):'';
+  try{
+    const {data:w,error}=await supabase.from('witches').select('name,price_cents').eq('id',witchIdNum).single();
+    if(error||!w||typeof w.price_cents!=='number'||w.price_cents<=0) return res.status(400).json({error:'Invalid witch'});
+    const metadata:Stripe.MetadataParam={teamId:String(teamIdNum),witchId:String(witchIdNum),type};
+    if(sanitizedNote) metadata.note=sanitizedNote;
+    const pi=await stripe.paymentIntents.create({
+      amount:w.price_cents,currency:'usd',description:`${type.toUpperCase()} by ${w.name}`,
+      metadata,
+      automatic_payment_methods:{enabled:true},
+    });
+    res.json({clientSecret:pi.client_secret});
+  }catch(err){
+    console.error('Failed to create payment intent',err);
+    const message=err instanceof Error?err.message:'Failed to create payment intent';
+    res.status(500).json({error:message});
+  }
 }

--- a/pages/pay.tsx
+++ b/pages/pay.tsx
@@ -5,6 +5,7 @@ import { loadStripe } from '@stripe/stripe-js';
 import { Elements, PaymentElement, useElements, useStripe } from '@stripe/react-stripe-js';
 
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY || '');
+const NOTE_MAX_LENGTH = 500;
 
 function CheckoutForm(){
   const stripe=useStripe(); const elements=useElements();
@@ -37,7 +38,8 @@ export default function PayPage(){
   useEffect(()=>{ if(!init.teamId||!init.witchId) return; (async()=>{
     try{
       setIntentError(null);
-      const res=await fetch('/api/create_payment_intent',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({...init,note})});
+      const payloadNote=note.slice(0,NOTE_MAX_LENGTH);
+      const res=await fetch('/api/create_payment_intent',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({...init,note:payloadNote})});
       if(!res.ok){
         const message=await res.text();
         throw new Error(message||'Failed to create payment intent');
@@ -53,7 +55,8 @@ export default function PayPage(){
   if(!clientSecret) return <main className="max-w-xl mx-auto p-6">
     <h1 className="text-2xl font-bold mb-3">Add your intent</h1>
     <label className="block text-sm mb-2">What exactly are you blessing/curing? (free text)</label>
-    <textarea value={note} onChange={e=>setNote(e.target.value)} className="w-full p-2 rounded bg-black/40 border border-gray-700" rows={4} placeholder="e.g., Bless the Bears' O-line vs Packers, Week 1"/>
+    <textarea value={note} onChange={e=>setNote(e.target.value)} maxLength={NOTE_MAX_LENGTH} className="w-full p-2 rounded bg-black/40 border border-gray-700" rows={4} placeholder="e.g., Bless the Bears' O-line vs Packers, Week 1"/>
+    <div className="text-xs opacity-60 mt-1 text-right">{note.length}/{NOTE_MAX_LENGTH} characters</div>
     {intentError?<p className="text-red-400 text-sm mt-3">{intentError}</p>:<div className="opacity-70 text-sm mt-3">Preparing payment...</div>}
   </main>;
 
@@ -61,7 +64,8 @@ export default function PayPage(){
     <main className="max-w-xl mx-auto p-6">
       <h1 className="text-2xl font-bold">Complete your {init.type}</h1>
       <label className="block text-sm mb-2 mt-4">What exactly are you blessing/curing? (free text)</label>
-      <textarea value={note} onChange={e=>setNote(e.target.value)} className="w-full p-2 rounded bg-black/40 border border-gray-700" rows={4} placeholder="e.g., Bless the Bears' O-line vs Packers, Week 1"/>
+      <textarea value={note} onChange={e=>setNote(e.target.value)} maxLength={NOTE_MAX_LENGTH} className="w-full p-2 rounded bg-black/40 border border-gray-700" rows={4} placeholder="e.g., Bless the Bears' O-line vs Packers, Week 1"/>
+      <div className="text-xs opacity-60 mt-1 text-right">{note.length}/{NOTE_MAX_LENGTH} characters</div>
       <CheckoutForm/>
     </main>
   </Elements>);


### PR DESCRIPTION
## Summary
- clamp metadata notes in the payment intent API and add validation/error handling
- limit the client note field to 500 characters and show a live character counter before checkout

## Testing
- npm run build *(fails: supabaseUrl is required without Supabase environment variables)*

------
https://chatgpt.com/codex/tasks/task_e_68d02faa9808833284a4eda6d590d7d4